### PR TITLE
Fix race condition

### DIFF
--- a/queue.js
+++ b/queue.js
@@ -21,8 +21,8 @@ export default class Queue {
 	dequeue(hash) {
 		const q = this.queueRunning;
 		const idx = q.findIndex(x => x.hash === hash);
-		if (idx == -1)
-			throw 'queue desync';
+		if (idx === -1)
+			throw 'queue desync';  // eslint-disable-line no-throw-literal
 		const o = q[idx];
 		q.splice(idx, 1);
 		return o;
@@ -67,7 +67,7 @@ export default class Queue {
 		/* Us on the queue */
 		let me = { hash, priority };
 		/* Create priorities on the fly */
-		if (this.queueWaiting[priority] == undefined)
+		if (this.queueWaiting[priority] === undefined)
 			this.queueWaiting[priority] = [];
 
 		/* Are we allowed to run? */


### PR DESCRIPTION
Fixed a race condition that could make low-priority tasks run before high-priority tasks.

The race condition happens as follows:

1. A task finishes, and calls end()
2. end() calls dequeue(), which removes the task from 'runningQueue'. So the length of 'runningQueue' is now smaller than 'maxConcurrent'.
3. end() calls resolve(). This is supposed to wake up the wait() function for the task, which had been sleeping ever since the task started (in the line 'await me.promise').
4. However, because resolve() was called, the JavaScript runtime is allowed to run **other** async code blocks. Suppose there was a pending code block that adds another task to the queue. In that case, wait() is called for the **new** task (not for the task that just finished).
5. wait() checks if it's allowed to start executing the task immediately, and it thinks that it **is** allowed, because 'this.queueRunning.length' was decremented by end(), so it looks like there's an open slot. So the new task starts executing immediately, regardless of its priority, and regardless of how many other tasks are currently waiting in the queue.
6. After all this, wait() is finally released for the **previous** task (from Step 1), in the line 'await me.promise'. But it's too late now; we already started executing a new task that we shouldn't have executed.

The solution is to keep track of the number of running tasks using an explicit variable ('numRunning'), instead of using 'queueRunning.length'. This bridges the gap between end() and wait(), so that it never looks like there's an open slot when there isn't one.