### PR TITLE
avoid returning nested promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [2.1.3] 2023-02-22
+- Accept only `async` functions as a parameter to `Queue.run()` and avoid returning nested promises
+
 ### [2.1.2] 2023-02-02
 - Move the debug statements to `rollup.config.mjs` to eliminate `process` references from the output file
 
@@ -22,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [2.0.0] 2023-01-19
 - Almost complete rewrite in TypeScript
 - Use `PriorityQueue` from `typescript-collection`
-- O(log(n)) in all cases
+- `O(log(n))` in all cases
 - Switch to mocha and test CJS/ES6/TS
 - Many bugs and edge cases fixed
 - The preferred way to import is now via the named export but the default export is still there
@@ -34,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.0] 2021-06-02
 
 ### Added
- - Add a run() method
+ - Add a `run()` method
 
 ### [1.1.1] 2020-06-13
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,7 @@ export class Queue<T = unknown> {
    * @param {number} [priority=0] Optional priority, -1 is higher priority than 1
    * @return {Promise<any>} Resolved when the task has finished with the return value of fn
    */
-  run<U>(job: () => U, priority?: number): Promise<U> {
+  run<U>(job: () => Promise<U>, priority?: number): Promise<U> {
     const prio = priority ?? 0;
     const id = Symbol();
     return this.wait(id as T, prio)

--- a/test/ts.test.ts
+++ b/test/ts.test.ts
@@ -10,10 +10,10 @@ describe('TS import', () => {
 
     q.wait(Symbol(), 0);
 
-    const s: Promise<symbol> = q.run(() => Symbol());
+    const s: Promise<symbol> = q.run(() => Promise.resolve(Symbol()));
     assert.instanceOf(s, Promise<symbol>);
 
-    const t: Promise<symbol> = q.run(() => Symbol(), 12);
+    const t: Promise<symbol> = q.run(() => Promise.resolve(Symbol()), 12);
     assert.instanceOf(t, Promise<symbol>);
   });
 
@@ -23,10 +23,10 @@ describe('TS import', () => {
 
     q.wait(Symbol() as unknown, 0);
 
-    const s: Promise<symbol> = q.run(() => Symbol());
+    const s: Promise<symbol> = q.run(() => Promise.resolve(Symbol()));
     assert.instanceOf(s, Promise<symbol>);
 
-    const t: Promise<symbol> = q.run(() => Symbol(), 12);
+    const t: Promise<symbol> = q.run(() => Promise.resolve(Symbol()), 12);
     assert.instanceOf(t, Promise<symbol>);
   });
 });


### PR DESCRIPTION
`Queue.run()` has no meaningful uses if the passed function does not return a `Promise`